### PR TITLE
Fix/connect top tracks data

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -20,33 +20,44 @@ class App extends Component {
   }
 
   componentDidMount = () => {
+    this.retrieveTopTracks();
+    this.retrieveTopArtists();
+  }
+
+  retrieveTopArtists = () => {
     apiCalls.getTopArtists()
       .then(data => {
+        console.log(data);
         this.setState({topArtists: data})
       })
       .catch(error => {
         console.log(error);
         this.setState({error: error.message})
       })
-      console.log(this.state.topArtists);
   }
-
- showTopTracks = async () => {
-     apiCalls.getTopTracks()
+  
+  retrieveTopTracks = () => {
+    apiCalls.getTopTracks()
       .then(data => {
-        this.setState({topTracks: data.topTracks})
+        console.log(data);
+        this.setState({ topTracks: data })
       })
       .catch(error => {
         console.log(error);
-        this.setState({error: error.message})
+        this.setState({ error: error.message })
       })
   }
+  
 
   render() {
 
     if (this.state.error > 1) {
       console.log(this.state.error);
       return <h2 className='message'>{this.state.error}</h2>
+    }
+
+    if (this.state.error < 1 && this.state.topTracks < 1) {
+      return <h2 className='message'>Page Loading</h2>
     }
 
     if (this.state.error < 1 && this.state.topArtists < 1) {
@@ -61,9 +72,9 @@ class App extends Component {
           <main className='main-section'>
             <section className='location-display'>
               <TopArtists topArtists={this.state.topArtists}/>
-              <TopTracks />
+              <TopTracks topTracks={this.state.topTracks}/>
             </section>
-            {/*
+            {/*             
             <section className='artist-display'>
               <ArtistInfo />
               <ArtistTracks />

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -20,8 +20,8 @@ class App extends Component {
   }
 
   componentDidMount = () => {
-    this.retrieveTopTracks();
     this.retrieveTopArtists();
+    this.retrieveTopTracks();
   }
 
   retrieveTopArtists = () => {
@@ -47,7 +47,6 @@ class App extends Component {
         this.setState({ error: error.message })
       })
   }
-  
 
   render() {
 
@@ -56,11 +55,7 @@ class App extends Component {
       return <h2 className='message'>{this.state.error}</h2>
     }
 
-    if (this.state.error < 1 && this.state.topTracks < 1) {
-      return <h2 className='message'>Page Loading</h2>
-    }
-
-    if (this.state.error < 1 && this.state.topArtists < 1) {
+    if (this.state.error < 1 && (this.state.topArtists < 1 || this.state.topTracks < 1)) {
       return <h2 className='message'>Page Loading</h2>
     }
 

--- a/src/components/App/_app.scss
+++ b/src/components/App/_app.scss
@@ -3,7 +3,6 @@
   padding: 0;
 }
 
-
 html {
   height: 100%;
   background-color: $rich-black;

--- a/src/components/Form/Form.js
+++ b/src/components/Form/Form.js
@@ -1,6 +1,5 @@
 import React from 'react';
 
-
 const Form = () => {
 
   return (
@@ -16,6 +15,5 @@ const Form = () => {
     </div>
   )
 }
-
 
 export default Form;

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -14,5 +14,4 @@ const Header = () => {
   )
 }
 
-
 export default Header;

--- a/src/components/TopArtists/TopArtists.js
+++ b/src/components/TopArtists/TopArtists.js
@@ -6,8 +6,6 @@ const TopArtists = ({topArtists}) => {
     return elem.name;
   });
 
-  console.log(artistNames);
-
   return (
     <article className='top-artists-box'>
       <h3> Top Artists in *location* </h3>
@@ -22,7 +20,7 @@ const TopArtists = ({topArtists}) => {
           <li className='top-artist'>{artistNames[6]}</li>
           <li className='top-artist'>{artistNames[7]}</li>
           <li className='top-artist'>{artistNames[8]}</li>
-          <li className='top-artist'>{artistNames[9]}1</li>
+          <li className='top-artist'>{artistNames[9]}</li>
         </ol>
       </div>
     </article>

--- a/src/components/TopTracks/TopTracks.js
+++ b/src/components/TopTracks/TopTracks.js
@@ -1,21 +1,27 @@
 import React from 'react';
 
-const TopTracks = () => {
+const TopTracks = ({topTracks}) => {
+
+  const trackFind = topTracks.tracks.track.reduce((finalArray, currentArtist) => {
+    finalArray.push({artist: currentArtist.artist.name, title: currentArtist.name});
+    return finalArray;
+  },[]);
+
   return (
     <article className='top-tracks-box'>
       <h3> Top Tracks in *location* </h3>
       <div className='tracks-list'>
         <ol>
-          <li className='top-track'>Track #1</li>
-          <li className='top-track'>Track #2</li>
-          <li className='top-track'>Track #3</li>
-          <li className='top-track'>Track #4</li>
-          <li className='top-track'>Track #5</li>
-          <li className='top-track'>Track #6</li>
-          <li className='top-track'>Track #7</li>
-          <li className='top-track'>Track #8</li>
-          <li className='top-track'>Track #9</li>
-          <li className='top-track'>Track #10</li>
+          <li className='top-track'>{trackFind[0].artist} - "{trackFind[0].title}"</li>
+          <li className='top-track'>{trackFind[1].artist} - "{trackFind[1].title}"</li>
+          <li className='top-track'>{trackFind[2].artist} - "{trackFind[2].title}"</li>
+          <li className='top-track'>{trackFind[3].artist} - "{trackFind[3].title}"</li>
+          <li className='top-track'>{trackFind[4].artist} - "{trackFind[4].title}"</li>
+          <li className='top-track'>{trackFind[5].artist} - "{trackFind[5].title}"</li>
+          <li className='top-track'>{trackFind[6].artist} - "{trackFind[6].title}"</li>
+          <li className='top-track'>{trackFind[7].artist} - "{trackFind[7].title}"</li>
+          <li className='top-track'>{trackFind[8].artist} - "{trackFind[8].title}"</li>
+          <li className='top-track'>{trackFind[9].artist} - "{trackFind[9].title}"</li>
         </ol>
       </div>
     </article>

--- a/src/utilities/apiCalls.js
+++ b/src/utilities/apiCalls.js
@@ -26,6 +26,7 @@ const apiCalls = {
 
 export default apiCalls;
 
+
 // export const getSelectedArtist = (id) => {
 //   const selectedArtistDetails = fetch(artistInfoUrl)
 //       .then(response => {

--- a/src/utilities/apiCalls.js
+++ b/src/utilities/apiCalls.js
@@ -20,37 +20,20 @@ const apiCalls = {
     const response = await fetch(topTracksByCountryUrl);
     const data = await response.json();
     return data;
-  }
+  },
 
+  // async getSelectedArtist(id) {
+  //   const response = await fetch(artistInfoUrl)
+  //   const data = await response.json();
+  //   return data;
+  // },
+
+  // async selectedArtistImage(id) {
+  //   const response = await fetch(artistImageUrl)
+  //   const data = await response.json();
+  //   return data;
+  // },
 }
 
 export default apiCalls;
 
-
-// export const getSelectedArtist = (id) => {
-//   const selectedArtistDetails = fetch(artistInfoUrl)
-//       .then(response => {
-//         if (response.ok) {
-//           return response.json()
-//         } else {
-//           throw new Error(`Error, please try again!`)
-//         }
-//       })
-//
-//   const selectedArtistImage = fetch(artistImageUrl)
-//       .then(response => {
-//         if (response.ok) {
-//           return response.json()
-//         } else {
-//           throw new Error(`Error, please try again!`)
-//         }
-//       })
-//
-//   return Promise.all([artistInfoUrl, artistImageUrl])
-//       .then(data => {
-//         let allData = {};
-//         allData.selectedArtistDetails = data[0];
-//         allData.selectedArtistImage = data[1];
-//         return allData;
-//       })
-// }


### PR DESCRIPTION
### Is this a fix or a feature?
- Fix

### What is the change or fix?
- Refactored `componentDidMount()` (_App.js_), `trackFind()` (_TopTracks.js_), and `apiCalls()` (_apiCalls.js_ - I had to revert to implementing async functionality within the API calls).  Our "Top Tracks" data is now fetching and displaying asyncronously alongside the "Top Artists" data.
- There were a few issues combining to throw multiple errors: 
1.  We **do** need both functions invoked within `componentDidMount()`, but they need to have _already_  'await'-ed and returned their data before re-setting state (which is why async/await functionality does need to be in `apiCalls()`, I think).
2.  We needed to add "loading"  conditional rending for `this.state.topTracks`, as well.  I build it into our pre-existing conditional block.
3.  The track names were nested even deeper than we thought - found them buried all the way down at `topTracks.tracks.track` 🙄.   Fixed the dot notation in `trackFind()`, as well as within the list item values (it was throwing errors because the DOM can't display the whole 'track object' as a list item - rewrote to reference the properties within).

### How should this be tested?
- Display in browser and add new Cypress testing.

### What's next?
- We should be able to move along with our data fetching and display!  I'm gonna start by reformatting our home page to display "artist cards" instead of the list of names.  Once the new layout is set up, I'll see about fetching and displaying those artist images.
