### PR TITLE
Fix/dynamic artist page routing

### DIFF
--- a/src/components/ArtistInfo/ArtistInfo.js
+++ b/src/components/ArtistInfo/ArtistInfo.js
@@ -3,7 +3,9 @@ import { useSelector, useDispatch } from 'react-redux';
 import { current, info } from '../../actions';
 import apiCalls from '../../utilities/apiCalls';
 
-const ArtistInfo = ({ }) => {
+const ArtistInfo = ({ id }) => {
+
+  const [ directory, path ]  = id.split(':');
 
   // how do we retrieve artist name from "card click" 
   // and assign to 'currentCard' in the store?
@@ -17,8 +19,7 @@ const ArtistInfo = ({ }) => {
 
   ////// TEMP FUNCTION
   useEffect(() => {
-    const artistName = "David Bowie";
-    dispatch(current(artistName));
+    dispatch(current(path));
   }, []);
   //////
   

--- a/src/components/ArtistInfo/ArtistInfo.js
+++ b/src/components/ArtistInfo/ArtistInfo.js
@@ -37,7 +37,6 @@ const ArtistInfo = ({ }) => {
   }
 
   return (
-
     !artistInfo.name ? 
       <section className='message-box'>
         <p className='message'>Page Loading</p>

--- a/src/components/ArtistInfo/ArtistInfo.js
+++ b/src/components/ArtistInfo/ArtistInfo.js
@@ -47,9 +47,8 @@ const ArtistInfo = ({ }) => {
         <div className='artist-img-box'>
           *artist image here*
         </div>
-        <h3 className='artist-name'>{artistInfo.name}</h3>
+        <a className='artist-name' href={artistInfo.url}>{artistInfo.name}</a>
         <div className='artist-text-box'>
-          <p className='artist-summary'>{artistInfo.bio.summary}</p>
           <p className='artist-bio'>{artistInfo.bio.content}</p>
         </div>
       </section>

--- a/src/components/ArtistInfo/_artist-info.scss
+++ b/src/components/ArtistInfo/_artist-info.scss
@@ -34,7 +34,7 @@
   background-color: rgba(6, 11, 38, 0.845);
 
   p {
-    color: rgba(255, 255, 255, 0.75);
+    color: $mid-emphasis-text;
     font-size: 1.5vw;
     margin: 3vw 2vw 4vw 2vw;
     font-family: $inconsolata;

--- a/src/components/ArtistInfo/_artist-info.scss
+++ b/src/components/ArtistInfo/_artist-info.scss
@@ -25,7 +25,7 @@
   justify-content: center;
   text-align: center;
   width: 85%;
-  margin-top: 2vw;
+  margin-top: 3vw;
   padding: 1vw 3vw 1vw 3vw;
   overflow: scroll;
   overscroll-behavior: contain;
@@ -43,7 +43,7 @@
 }
 
 .artist-name {
-  margin: 4vw auto 2vw auto;
+  margin: 5vw auto 3vw auto;
   justify-self: center;
   font-size: 3vw;
   font-family: AlienEncounters;

--- a/src/components/ArtistInfo/_artist-info.scss
+++ b/src/components/ArtistInfo/_artist-info.scss
@@ -51,8 +51,7 @@
   color: $fashion-fuscia;
 }
 
-// .artist-summary {
-// }
-
-// .artist-bio {
-// }
+.artist-url {
+  font-size: 2vw;
+  color: $green-blue-crayola;
+}

--- a/src/components/Form/_form.scss
+++ b/src/components/Form/_form.scss
@@ -5,7 +5,7 @@ form {
   height: 7vw;
   margin: 1vw;
   color: whitesmoke;
-  background-color: rgba(19, 99, 142, 0.188);
+  background-color: $opaque-blue;
   box-shadow: $shadow-heavy;
 
   select, input {

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -9,10 +9,10 @@ const Header = () => {
       <h1 className='glow'>W o r m h o l e</h1>
       <nav>
         <Link exact to='/'>
-          <button className='random-location'>Randomize Location</button>
+          <button className='nav-btn'>Randomize Location</button>
         </Link>
         <Link exact to='/'>
-          <button className='go-home'>Return Home</button>
+          <button className='nav-btn'>Return Home</button>
         </Link>
       </nav>
     </header>

--- a/src/components/Header/_header.scss
+++ b/src/components/Header/_header.scss
@@ -1,9 +1,9 @@
 header {
   display: grid;
-  grid-template-rows: 70% 30%;
+  grid-template-rows: 60% 30%;
   align-items: center;
   background-color: $rich-black;
-  height: 14vw;
+  height: 16vw;
   border-bottom: 6px solid $blue-jeans;
 }
 
@@ -19,10 +19,25 @@ h1 {
 nav {
   display: flex;
   flex-direction: row;
-  justify-content: flex-end;
-  width: 100%;
+  justify-content: space-between;
+  align-items: flex-end;
+  margin-bottom: 0;
+  width: 99%;
 }
 
-button {
-  margin: 1vw;
-}
+.nav-btn {
+    width: 15vw;
+    height: 3vw;
+    margin: 2vw 3vw 0 3vw;
+    font-family: $inconsolata;
+    font-size: 1.2vw;
+    border: 1px solid #ed33b86c;
+    color: $green-lizzard;
+    background-color: rgba(12, 22, 48, 0.51);
+
+    &:hover {
+      border: 1px solid $icerine;
+      color: $mid-emphasis-text;
+      background-color: $opaque-blue;
+    }
+  }

--- a/src/components/TopArtists/TopArtists.js
+++ b/src/components/TopArtists/TopArtists.js
@@ -89,7 +89,7 @@ const TopArtists = () => {
       </section>
       :
       <section className='top-artists-box'>
-        <h3> Top Artists in {location.name} </h3>
+        <h3> Top Artists: <br></br> {location.name} </h3>
         <div className='artists-list'>
           {artistCards}
         </div>

--- a/src/components/TopArtists/_top-artists.scss
+++ b/src/components/TopArtists/_top-artists.scss
@@ -11,10 +11,10 @@
 
   h3 {
     margin-top: 1vw;
-    align-self: flex-start;
+    align-self: center;
     font-family: AlienEncounters;
     font-style: italic;
-    font-size: 2vw;
+    font-size: 2.5vw;
     line-height: 2;
     color: $fashion-fuscia;
   }

--- a/src/components/TopArtists/_top-artists.scss
+++ b/src/components/TopArtists/_top-artists.scss
@@ -1,6 +1,6 @@
 .top-artists-box {
   display: grid;
-  grid-template-rows: 10% 90%;
+  grid-template-rows: 15% 85%;
   padding: 2vw 2vw 2vw 4vw;
   width: 45%;
   height: auto;
@@ -10,11 +10,12 @@
   border: 1px solid $blue-jeans;
 
   h3 {
-    margin: 2.5vw auto 2vw auto;
-    justify-self: center;
+    margin-top: 1vw;
+    align-self: flex-start;
     font-family: AlienEncounters;
     font-style: italic;
     font-size: 2vw;
+    line-height: 2;
     color: $fashion-fuscia;
   }
 
@@ -27,6 +28,10 @@
   display: flex;
   flex-flow: row wrap;
   justify-content: flex-start;
+  margin-top: 2vw;
+  color: $mid-emphasis-text;
+  font-size: 1.5vw;
+  font-family: $inconsolata;
 }
 
 .top-artist-card {

--- a/src/components/TopTracks/TopTracks.js
+++ b/src/components/TopTracks/TopTracks.js
@@ -32,7 +32,7 @@ const TopTracks = () => {
   const filterTracks = (data) => {
     const topTracks = data.reduce((topTen, trackObj) => {
       if (data.indexOf(trackObj) < 10) {
-        topTen.push({artist: trackObj.artist.name, title: trackObj.name});
+        topTen.push({ url: trackObj.url, artist: trackObj.artist.name, title: trackObj.name});
       }
       return topTen;
     }, []);
@@ -40,8 +40,11 @@ const TopTracks = () => {
   } 
 
   const buildTrackList = (topTracks) => topTracks.map(track => {
+
     return (
-      <li key={topTracks.indexOf(track)}>{track.artist} - "{track.title}"</li>
+      <li className='top-track' key={topTracks.indexOf(track)}>
+        <a href={track.url}>{track.artist} - "{track.title}"</a>
+      </li>
     )
   });
 
@@ -52,7 +55,7 @@ const TopTracks = () => {
       </section> 
       :
       <section className='top-tracks-box'>
-        <h3> Top Tracks in {location.name} </h3>
+        <h3> Top Tracks: <br></br> {location.name} </h3>
         <div className='tracks-list'>
           <ol>
             {trackList}

--- a/src/components/TopTracks/_top-tracks.scss
+++ b/src/components/TopTracks/_top-tracks.scss
@@ -1,7 +1,6 @@
 .top-tracks-box {
   display: flex;
   flex-direction: column;
-  justify-content: space-around;
   padding: 2vw 2vw 2vw 4vw;
   width: 35%;
   height: auto;
@@ -11,18 +10,18 @@
   border: 1px solid $blue-jeans;
 
   h3 {
-    margin-top: 1vw;
+    margin-top: 2vw;
     align-self: flex-start;
     font-family: AlienEncounters;
     font-style: italic;
-    font-size: 2vw;
+    font-size: 2.5vw;
     line-height: 2;
     color: $fashion-fuscia;
   }
 }
 
 .tracks-list {
-  margin: 2vw 2vw 4vw 2vw;
+  margin: 4vw 2vw 4vw 2vw;
   color: $mid-emphasis-text;
   font-size: 1.5vw;
   font-family: $inconsolata;
@@ -31,7 +30,6 @@
 
 .top-track {
   margin-bottom: 2vw;
-
 }
 
 .top-track a {

--- a/src/components/TopTracks/_top-tracks.scss
+++ b/src/components/TopTracks/_top-tracks.scss
@@ -1,6 +1,7 @@
 .top-tracks-box {
   display: flex;
   flex-direction: column;
+  justify-content: space-around;
   padding: 2vw 2vw 2vw 4vw;
   width: 35%;
   height: auto;
@@ -10,15 +11,36 @@
   border: 1px solid $blue-jeans;
 
   h3 {
-    margin: 3vw auto 2vw auto;
-    align-self: center;
+    margin-top: 1vw;
+    align-self: flex-start;
     font-family: AlienEncounters;
     font-style: italic;
     font-size: 2vw;
+    line-height: 2;
     color: $fashion-fuscia;
   }
+}
 
-  li {
-    margin: 1vw;
-  }
+.tracks-list {
+  margin: 2vw 2vw 4vw 2vw;
+  color: $mid-emphasis-text;
+  font-size: 1.5vw;
+  font-family: $inconsolata;
+  line-height: 2;
+}
+
+.top-track {
+  margin-bottom: 2vw;
+
+}
+
+.top-track a {
+    list-style-type: none;
+    display: inline;
+    text-decoration: none;
+    color: $mid-emphasis-text;
+
+    &:hover {
+      color: $blue-jeans;
+    }
 }

--- a/src/utilities/_variables.scss
+++ b/src/utilities/_variables.scss
@@ -10,8 +10,10 @@ $yale-blue: #004782;
 $persian-indigo: #3B1275;
 $dark-sienna: #2F0F12;
 $xiketic: #1F0812;
+$opaque-blue: rgba(19, 99, 142, 0.188);
 
 // light
+$mid-emphasis-text: rgba(255, 255, 255, 0.75);
 $beau-blue: #D6EDFF;
 $cream: #FFFFC7;
 


### PR DESCRIPTION
### Is this a fix or a feature?
- Fix, with some CSS features as well.

### What is the change or fix?
- Fixed the <ArtistInfo> route so that we use `match.params.id` (the artist name in the URL) to dynamically fetch different artist info API objects, do be rendered on the AristInfo page display.  
- Refactored the "artist name" HTML element (in the ArtistInfo display) so that it's now a hyperlink that can be clicked to take the user to that artist's Last.fm page.
- Same for each TopTrack <li> on the home page view - individual track names can be clicked to reroute to that song's Last.fm page.
- Restyled the Header's nav buttons ("Randomize Location" and "Return Home") so that they better fit with our UI, including a hover effect to communicate that they can be clicked.
- Removed the "artist summary" element from ArtistInfo, since it's just the first paragraph of the longer "artist bio" element.  
- Refactored the "artist info" container styling so that when you scroll down to view more text, the parent container / entire page remains fixed in it's position.

### How should this be tested?
- Display in browser.
- We should now be able to implement Cypress testing for all ArtistInfo components and functionality, now that it loads and renders the correct data.

### Linked Issues:
- #9 #33 
